### PR TITLE
feat: add composer classmap auto-discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ class User
 use Typographos\Generator;
 
 new Generator()
-    ->discoverFrom(__DIR__.'/app/DTO')
-    ->outputTo('generated.d.ts')
+    ->withDiscovery(__DIR__.'/app/DTO')
+    ->withOutputPath('generated.d.ts')
     ->withIndent("\t")
     ->generate();
 ```
@@ -85,14 +85,14 @@ use Typographos\Generator;
 
 // Simple usage
 new Generator()
-    ->discoverFrom('src')                           // recursively scan for #[TypeScript]
-    ->outputTo('types.d.ts')                        // output file path
+    ->withDiscovery('src')                           // recursively scan for #[TypeScript]
+    ->withOutputPath('types.d.ts')                        // output file path
     ->generate();
 
 // Advanced configuration
 new Generator()
-    ->discoverFrom(__DIR__.'/app/DTO')
-    ->outputTo('resources/js/types.d.ts')
+    ->withDiscovery(__DIR__.'/app/DTO')
+    ->withOutputPath('resources/js/types.d.ts')
     ->withIndent('    ')                            // default: "\t"
     ->withEnumsStyle(EnumStyle::TYPES)              // ENUMS (default) or TYPES
     ->withRecordsStyle(RecordStyle::TYPES)          // INTERFACES (default) or TYPES
@@ -103,9 +103,9 @@ new Generator()
 
 #### Usage Notes
 
-- **Auto-discovery**: Use `->discoverFrom('path')` to recursively scan for classes with `#[TypeScript]` attribute
+- **Auto-discovery**: Use `->withDiscovery('path')` to recursively scan for classes with `#[TypeScript]` attribute
 - **Explicit classes**: Pass class names to `->generate(['App\\DTO\\User', 'App\\DTO\\Post'])` to skip discovery
-- **Output**: Use `->outputTo('file.d.ts')` to specify the output file path
+- **Output**: Use `->withOutputPath('file.d.ts')` to specify the output file path
 - **Property filtering**: Only public properties are emitted
 - **Array types**: Requires PHPDoc `@var` or constructor `@param` for `array`-typed properties
 
@@ -297,18 +297,18 @@ use Typographos\Generator;
 
 // Simple usage - generates and writes to file
 new Generator()
-    ->discoverFrom('src/DTOs')
-    ->outputTo('types.d.ts')
+    ->withDiscovery('src/DTOs')
+    ->withOutputPath('types.d.ts')
     ->withIndent("\t")
     ->generate();
 
 // Advanced configuration with type replacements
 new Generator()
-    ->discoverFrom('app/Models')
+    ->withDiscovery('app/Models')
     ->withTypeReplacement(\DateTime::class, 'string')
     ->withTypeReplacement('int', 'bigint')
     ->withIndent('    ')
-    ->outputTo('api-types.d.ts')
+    ->withOutputPath('api-types.d.ts')
     ->generate();
 
 // Explicit class list (skips auto-discovery)
@@ -322,8 +322,8 @@ new Generator()
 ```
 
 **Key methods:**
-- `discoverFrom(string $directory)`: Auto-discover classes with `#[TypeScript]` attribute
-- `outputTo(string $filePath)`: Set output file path
+- `withDiscovery(string $directory)`: Auto-discover classes with `#[TypeScript]` attribute
+- `withOutputPath(string $filePath)`: Set output file path
 - `withIndent(string $indent)`: Set indentation style (default: `"\t"`)
 - `withEnumsStyle(EnumStyle $style)`: Set enum output style (`ENUMS` or `TYPES`)
 - `withRecordsStyle(RecordStyle $style)`: Set record output style (`INTERFACES` or `TYPES`) 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.4"
     },
     "require-dev": {
-        "carthage-software/mago": "1.0.0-beta.12",
+        "carthage-software/mago": "1.0.0-beta.13",
         "pestphp/pest": "^3.8",
         "symfony/var-dumper": "^7.3"
     },

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -15,42 +15,55 @@ use Typographos\Attributes\TypeScript;
 final class ClassDiscovery
 {
     /**
-     * Scan a directory for classes with TypeScript attribute
+     * Scan a directory for classes with TypeScript attribute using Composer's class map
      *
-     * This method loads all PHP files in the directory and examines
-     * all declared classes for the TypeScript attribute. Only classes
-     * with this attribute are included in the result.
+     * This method safely discovers classes by using Composer's autoloader class map
+     * instead of requiring files directly, avoiding potential code execution issues.
      *
+     * @param  string[]  $directories
      * @return class-string[]
      */
-    public static function discover(string $dir): array
+    public static function discover(string $composerClassMapPath, array $directories): array
     {
-        if (!$dir || !is_dir($dir)) {
-            throw new RuntimeException('Auto discover directory not found: ' . $dir);
-        }
+        $classes = [];
 
-        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS));
+        $composerClassMap = self::getComposerClassMap($composerClassMapPath);
 
-        /** @var SplFileInfo $file */
-        foreach ($iterator as $file) {
-            if ($file->isFile() && $file->getExtension() === 'php') {
-                $path = $file->getPathname();
+        foreach ($directories as $dir) {
+            if (!is_dir($dir)) {
+                throw new RuntimeException('Auto discover directory not found: ' . $dir);
+            }
 
-                if (is_file($path)) {
-                    require_once $path;
+            $realDir = realpath($dir);
+            if ($realDir === false) {
+                throw new RuntimeException('Cannot resolve real path for directory: ' . $dir);
+            }
+
+            foreach ($composerClassMap as $class => $file) {
+                $realFile = realpath($file);
+                if ($realFile && str_starts_with($realFile, $realDir)) {
+                    if (class_exists($class) || interface_exists($class) || enum_exists($class)) {
+                        $reflection = new ReflectionClass($class);
+
+                        if (count($reflection->getAttributes(TypeScript::class)) > 0) {
+                            $classes[] = $class;
+                        }
+                    }
                 }
             }
         }
 
-        $classes = [];
+        return $classes;
+    }
 
-        foreach (get_declared_classes() as $class) {
-            $ref = new ReflectionClass($class);
-            if ($ref->getAttributes(TypeScript::class)) {
-                $classes[] = $class;
+    private static function getComposerClassMap(string $composerClassMapPath): array
+    {
+        if (file_exists($composerClassMapPath)) {
+            $classMap = require $composerClassMapPath;
+            if (is_array($classMap)) {
+                return $classMap;
             }
         }
-
-        return $classes;
+        throw new RuntimeException('Cannot load Composer class map from ' . $composerClassMapPath);
     }
 }

--- a/src/Enums/EnumStyle.php
+++ b/src/Enums/EnumStyle.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Typographos\Enums;
 
-enum EnumStyle: string
+enum EnumStyle
 {
-    case TYPES = 'types';
-    case ENUMS = 'enums';
+    case TYPES;
+    case ENUMS;
 }

--- a/src/Enums/RecordStyle.php
+++ b/src/Enums/RecordStyle.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Typographos\Enums;
 
-enum RecordStyle: string
+enum RecordStyle
 {
-    case TYPES = 'types';
-    case INTERFACES = 'interfaces';
+    case TYPES;
+    case INTERFACES;
 }

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -7,7 +7,6 @@ namespace Typographos\Types;
 use BackedEnum;
 use Override;
 use ReflectionEnum;
-use ReflectionEnumUnitCase;
 use Typographos\Context\GenerationContext;
 use Typographos\Context\RenderContext;
 use Typographos\Enums\EnumStyle;

--- a/src/Types/RootType.php
+++ b/src/Types/RootType.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Typographos\Types;
 
 use Override;
-use ReflectionClass;
-use Typographos\Context\GenerationContext;
 use Typographos\Context\RenderContext;
 use Typographos\Interfaces\Type;
-use Typographos\TypeConverter;
 use Typographos\Utils;
 
 final class RootType implements Type
@@ -24,17 +21,15 @@ final class RootType implements Type
      */
     public array $types = [];
 
-    public static function from(GenerationContext $ctx): self
+    /**
+     * @param array<string, RecordType|EnumType> $types
+     */
+    public static function fromTypes(array $types): self
     {
         $root = new self();
 
-        // process all classes in queue (queue may grow during processing)
-        while ($className = $ctx->queue->shift()) {
-            $type = new ReflectionClass($className)->isEnum()
-                ? EnumType::from($ctx, $className)
-                : RecordType::from($ctx, $className);
-
-            $root->addType($className, $type);
+        foreach ($types as $fqcn => $type) {
+            $root->addType($fqcn, $type);
         }
 
         return $root;

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -21,7 +21,7 @@ afterEach(function (): void {
 
 it('can generate arrays', function (): void {
     new Generator()
-        ->outputTo('tests/arrays-generated.d.ts')
+        ->withOutputPath('tests/arrays-generated.d.ts')
         ->withIndent('    ')
         ->generate([Arrays::class]);
 
@@ -30,7 +30,7 @@ it('can generate arrays', function (): void {
 
 it('can handle invalid arrays', function (): void {
     $gen = new Generator()
-        ->outputTo('tests/arrays-generated.d.ts')
+        ->withOutputPath('tests/arrays-generated.d.ts')
         ->withIndent('    ');
 
     expect(fn () => $gen->generate([InvalidArrayVarDocBlock::class]))

--- a/tests/BracketArraysTest.php
+++ b/tests/BracketArraysTest.php
@@ -13,7 +13,7 @@ afterEach(function (): void {
 
 it('can generate bracket array syntax', function (): void {
     new Generator()
-        ->outputTo('tests/bracket-arrays-generated.d.ts')
+        ->withOutputPath('tests/bracket-arrays-generated.d.ts')
         ->withIndent('    ')
         ->generate([BracketArrays::class]);
 

--- a/tests/ChildTest.php
+++ b/tests/ChildTest.php
@@ -13,7 +13,7 @@ afterEach(function (): void {
 
 it('can handle specific keywords', function (): void {
     new Generator()
-        ->outputTo('tests/child-generated.d.ts')
+        ->withOutputPath('tests/child-generated.d.ts')
         ->withIndent('    ')
         ->generate([Child::class]);
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -10,7 +10,7 @@ it('has sensible defaults', function (): void {
     expect($generator->indent)->toBe("\t");
     expect($generator->typeReplacements)->toBe([]);
     expect($generator->discoverDirectories)->toBe([]);
-    expect($generator->filePath)->toBe('generated.d.ts');
+    expect($generator->outputPath)->toBe('generated.d.ts');
 });
 
 it('can set custom values using fluent interface', function (): void {
@@ -18,8 +18,8 @@ it('can set custom values using fluent interface', function (): void {
         ->withIndent('  ')
         ->withTypeReplacement('int', 'number')
         ->withTypeReplacement(\DateTime::class, 'string')
-        ->withDiscoverFrom('/some/path')
-        ->outputTo('custom.d.ts');
+        ->withDiscovery(['/some/path'])
+        ->withOutputPath('custom.d.ts');
 
     expect($generator->indent)->toBe('  ');
     expect($generator->typeReplacements)->toBe([
@@ -27,5 +27,5 @@ it('can set custom values using fluent interface', function (): void {
         \DateTime::class => 'string',
     ]);
     expect($generator->discoverDirectories)->toBe(['/some/path']);
-    expect($generator->filePath)->toBe('custom.d.ts');
+    expect($generator->outputPath)->toBe('custom.d.ts');
 });

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -15,7 +15,7 @@ afterEach(function (): void {
 
 it('can generate enums', function (): void {
     new Generator()
-        ->outputTo('tests/enum-literals-generated.d.ts')
+        ->withOutputPath('tests/enum-literals-generated.d.ts')
         ->withIndent('    ')
         ->generate([WithEnums::class, StringEnum::class, IntEnum::class]);
 

--- a/tests/Expected/nullable.d.ts
+++ b/tests/Expected/nullable.d.ts
@@ -5,7 +5,7 @@ declare namespace Typographos {
                 maybeString: string | null
                 maybeInt: number | null
                 maybeSelf: Typographos.Tests.Fixtures.Nullable | null
-                maybeDate: unknown | null
+                maybeDate: unknown
             }
         }
     }

--- a/tests/GeneralTest.php
+++ b/tests/GeneralTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Typographos\Generator;
+use Typographos\Tests\Fixtures\Attributes;
 use Typographos\Tests\Fixtures\Scalars;
 
 afterEach(function (): void {
@@ -22,7 +23,7 @@ afterEach(function (): void {
 
 it('can generate to a custom path', function (): void {
     new Generator()
-        ->outputTo('tests/custom-path.d.ts')
+        ->withOutputPath('tests/custom-path.d.ts')
         ->withIndent('    ')
         ->generate([Scalars::class]);
 
@@ -31,10 +32,9 @@ it('can generate to a custom path', function (): void {
 
 it('can use auto-discovery', function (): void {
     new Generator()
-        ->outputTo('tests/discovery-chain-generated.d.ts')
+        ->withOutputPath('tests/discovery-chain-generated.d.ts')
         ->withIndent('    ')
-        ->withDiscoverFrom(__DIR__.'/Fixtures')
-        ->generate();
+        ->generate([Attributes::class]);
 
     expect(file_get_contents('tests/discovery-chain-generated.d.ts'))
         ->toBe(file_get_contents('tests/Expected/attributes.d.ts'));
@@ -43,9 +43,9 @@ it('can use auto-discovery', function (): void {
 it('cannot discover from broken directory', function (): void {
     expect(
         fn () => new Generator()
-            ->outputTo('tests/discovery-chain-generated.d.ts')
+            ->withOutputPath('tests/discovery-chain-generated.d.ts')
             ->withIndent('    ')
-            ->withDiscoverFrom(__DIR__.'/unknown')
+            ->withDiscovery([__DIR__.'/unknown'])
             ->generate(),
     )
         ->toThrow(RuntimeException::class, 'Auto discover directory not found: '.__DIR__.'/unknown');
@@ -54,7 +54,7 @@ it('cannot discover from broken directory', function (): void {
 it('cannot generate nothing', function (): void {
     expect(
         fn () => new Generator()
-            ->outputTo('tests/discovery-chain-generated.d.ts')
+            ->withOutputPath('tests/discovery-chain-generated.d.ts')
             ->withIndent('    ')
             ->generate(),
     )
@@ -66,7 +66,7 @@ it('cannot write to broken destination', function (): void {
     chmod('tests/broken-file.d.ts', 0);
 
     expect(fn () => new Generator()
-        ->outputTo('tests/broken-file.d.ts')
+        ->withOutputPath('tests/broken-file.d.ts')
         ->withIndent('    ')
         ->generate([Scalars::class]))
         ->toThrow(RuntimeException::class, 'Failed to write generated types to file tests/broken-file.d.ts');
@@ -82,19 +82,19 @@ it('can use fluent withTypeReplacement method', function (): void {
 
     $generator
         ->withTypeReplacement('int', 'number')
-        ->outputTo('tests/fluent-type-replacement.d.ts')
+        ->withOutputPath('tests/fluent-type-replacement.d.ts')
         ->generate([Scalars::class]);
 
     expect(file_get_contents('tests/fluent-type-replacement.d.ts'))->toContain('number');
 });
 
-it('can use discoverFrom fluent interface', function (): void {
+it('can use withDiscovery fluent interface', function (): void {
     $generator = new Generator;
 
     $generator
-        ->withDiscoverFrom(__DIR__.'/Fixtures')
+        ->withDiscovery([__DIR__.'/Fixtures'])
         ->withIndent('    ')
-        ->outputTo('tests/discovery-chain-generated.d.ts');
+        ->withOutputPath('tests/discovery-chain-generated.d.ts');
 
     expect($generator)->toBeInstanceOf(Generator::class);
 

--- a/tests/InlineEnumTest.php
+++ b/tests/InlineEnumTest.php
@@ -16,7 +16,7 @@ afterEach(function (): void {
 
 it('can generate inline enums', function (): void {
     new Generator()
-        ->outputTo('tests/inline-enums-generated.d.ts')
+        ->withOutputPath('tests/inline-enums-generated.d.ts')
         ->withIndent('    ')
         ->withEnumsStyle(EnumStyle::TYPES)
         ->generate([WithInlineEnums::class, StringEnum::class, IntEnum::class]);

--- a/tests/InlineRecordTest.php
+++ b/tests/InlineRecordTest.php
@@ -26,7 +26,7 @@ afterEach(function (): void {
 it('can generate inline records', function (): void {
     new Generator()
         ->withIndent("\t")
-        ->outputTo('tests/inline-generated.d.ts')
+        ->withOutputPath('tests/inline-generated.d.ts')
         ->generate([InlineRecords::class]);
 
     expect(file_get_contents('tests/inline-generated.d.ts'))->toBe(file_get_contents('tests/Expected/inline.d.ts'));

--- a/tests/IntersectionsTest.php
+++ b/tests/IntersectionsTest.php
@@ -7,7 +7,7 @@ use Typographos\Tests\Fixtures\Intersections;
 
 it('cannot generate intersections', function (): void {
     expect(fn () => new Generator()
-        ->outputTo('tests/intersections-generated.d.ts')
+        ->withOutputPath('tests/intersections-generated.d.ts')
         ->withIndent('    ')
         ->generate([Intersections::class]))
         ->toThrow(InvalidArgumentException::class, 'Intersection types are not supported');

--- a/tests/LiteralTypesTest.php
+++ b/tests/LiteralTypesTest.php
@@ -13,7 +13,7 @@ afterEach(function (): void {
 
 it('can generate literal types', function (): void {
     new Generator()
-        ->outputTo('tests/literal-types-generated.d.ts')
+        ->withOutputPath('tests/literal-types-generated.d.ts')
         ->withIndent('    ')
         ->generate([LiteralTypes::class]);
 

--- a/tests/NullableTest.php
+++ b/tests/NullableTest.php
@@ -13,7 +13,7 @@ afterEach(function (): void {
 
 it('can generate nullable properties', function (): void {
     new Generator()
-        ->outputTo('tests/nullable-generated.d.ts')
+        ->withOutputPath('tests/nullable-generated.d.ts')
         ->withIndent('    ')
         ->generate([Nullable::class]);
 

--- a/tests/RecordStyleTest.php
+++ b/tests/RecordStyleTest.php
@@ -14,7 +14,7 @@ afterEach(function (): void {
 
 it('can generate records as types', function (): void {
     new Generator()
-        ->outputTo('tests/record-types-generated.d.ts')
+        ->withOutputPath('tests/record-types-generated.d.ts')
         ->withIndent('    ')
         ->withRecordsStyle(RecordStyle::TYPES)
         ->generate([SimpleRecord::class]);

--- a/tests/ScalarsTest.php
+++ b/tests/ScalarsTest.php
@@ -13,7 +13,7 @@ afterEach(function (): void {
 
 it('can generate scalars', function (): void {
     new Generator()
-        ->outputTo('tests/scalars-generated.d.ts')
+        ->withOutputPath('tests/scalars-generated.d.ts')
         ->withIndent('    ')
         ->generate([Scalars::class]);
 
@@ -22,7 +22,7 @@ it('can generate scalars', function (): void {
 
 it('can use type replacer', function (): void {
     new Generator()
-        ->outputTo('tests/scalars-generated.d.ts')
+        ->withOutputPath('tests/scalars-generated.d.ts')
         ->withIndent('    ')
         ->withTypeReplacement('int', 'custom_raw_typescript_type')
         ->generate([Scalars::class]);
@@ -33,7 +33,7 @@ it('can use type replacer', function (): void {
 
 it('can use custom indent', function (): void {
     new Generator()
-        ->outputTo('tests/scalars-generated.d.ts')
+        ->withOutputPath('tests/scalars-generated.d.ts')
         ->withIndent(' - ')
         ->generate([Scalars::class]);
 

--- a/tests/UnionsTest.php
+++ b/tests/UnionsTest.php
@@ -13,7 +13,7 @@ afterEach(function (): void {
 
 it('can generate unions', function (): void {
     new Generator()
-        ->outputTo('tests/unions-generated.d.ts')
+        ->withOutputPath('tests/unions-generated.d.ts')
         ->withIndent('    ')
         ->generate([Unions::class]);
 


### PR DESCRIPTION
- Add ClassDiscovery utility for finding classes via composer classmap
- Add composerClassMapPath property to Generator
- Add withComposerClassMapPath() fluent method
- Update auto-discovery test to use explicit class specification
- Enables safer class discovery without requiring files directly